### PR TITLE
Remove useless if

### DIFF
--- a/server.py
+++ b/server.py
@@ -192,11 +192,8 @@ class Game:
                 return
             await self.send_lines(msg["lines"], client.uuid)
         elif msg["type"] == "dead":
-            if self.state == self.GAME_STATE_FINISHED:
-                print("User might just have died.. ignore")
-                return
             if self.state != self.GAME_STATE_RUNNING:
-                print("Game is not running. Error.")
+                print("User died while game not running.. Ignoring.")
                 return
             print("User died")
             # Get alive count..


### PR DESCRIPTION
Before, this thing was first checking if the matche's state is FINISHED and then if it checked if the match is not RUNNING, which only could mean the match hasn't begun yet. Since in both cases, literally nothing is done, I think it would be better to remove the first if clause and update the message in the second.